### PR TITLE
Replaced title text in titleContainer with logo

### DIFF
--- a/src/screens/components/TitleContainer.js
+++ b/src/screens/components/TitleContainer.js
@@ -17,8 +17,6 @@ class TitleContainer extends React.Component {
   }
 }
 
-//{resizeMode: "cover", width: "85%", height: "85%"}
-
 const styles = StyleSheet.create({
   TitleLogo: {
     width: "100%",


### PR DESCRIPTION
Small change to `TitleContainer.js` component, closes #59 

## PR:
![image](https://user-images.githubusercontent.com/55285451/116060338-13053600-a682-11eb-94d9-0afe94cad199.png)


## Before:
![image](https://user-images.githubusercontent.com/55285451/116060634-5364b400-a682-11eb-92c1-ffeb4bf216de.png)
